### PR TITLE
Fix RC TP byte calc and AstraSim artifact defaults

### DIFF
--- a/run_perf.py
+++ b/run_perf.py
@@ -202,7 +202,7 @@ def run_GEMM(
             f.write("Backward Reduction Time: {}\n".format(backward_red))
             if dp_reduction_time > 0:
                 f.write("DP Reduction Time: {}\n".format(dp_reduction_time))
-            f.write("Total Time: {}\n".format(total_time))
+        f.write("Total Time: {}\n".format(total_time))
     print("Performance Results written to {}".format(output_file))
     # Emit lines for astra_test parsing
     print("Total time: {}".format(total_time))


### PR DESCRIPTION
## Summary
- use ceiling division for RC tensor-parallel shard sizes so communication payloads cover remainder rows and columns
- ensure AstraSim transformer runs always receive valid artifact directories, even when persistence is disabled
- always emit a Total Time line in GEMM summaries, regardless of backward execution

## Testing
- python -m compileall run_perf.py time_calculation_LLM.py

------
https://chatgpt.com/codex/tasks/task_e_68d25c63aca88320b6863938fac82634